### PR TITLE
Vulcand Tests & Flag to trust headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .coverage
 htmlcov
+__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.4"
+  - "3.5"
 
 # install dependencies
 install: "pip install -r requirements.txt"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# @Author: ahuynh
+# @Date:   2016-01-28 10:04:58
+# @Last Modified by:   ahuynh
+# @Last Modified time: 2016-02-11 14:30:08
+
+
+class MockEtcd( object ):
+    def delete( self, value ):
+        pass
+
+    def write( self, value, ttl ):
+        pass

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,12 +3,28 @@
 # @Author: ahuynh
 # @Date:   2016-01-28 10:04:58
 # @Last Modified by:   ahuynh
-# @Last Modified time: 2016-02-11 14:30:08
+# @Last Modified time: 2016-02-11 17:25:54
+import etcd
 
 
 class MockEtcd( object ):
-    def delete( self, value ):
-        pass
 
-    def write( self, value, ttl ):
-        pass
+    def __init__( self, raise_exception=False ):
+        self._reset()
+        self.raise_exception = raise_exception
+
+    def _check_raise( self ):
+        if self.raise_exception:
+            raise etcd.EtcdException( 'Test Exception' )
+
+    def _reset( self ):
+        self.deleted = set([])
+        self.written = {}
+
+    def delete( self, key ):
+        self._check_raise()
+        self.deleted.add( key )
+
+    def write( self, key, value, ttl ):
+        self._check_raise()
+        self.written[ key ] = value

--- a/tests/backends/test_vulcand.py
+++ b/tests/backends/test_vulcand.py
@@ -3,12 +3,12 @@
 # @Author: ahuynh
 # @Date:   2016-02-11 14:28:02
 # @Last Modified by:   ahuynh
-# @Last Modified time: 2016-02-11 15:33:08
+# @Last Modified time: 2016-02-11 17:27:07
 import unittest
 
 from sidekick import announce_services, find_matching_container, parse_args
-
 from tests import MockEtcd
+from unittest.mock import patch
 
 
 class TestVulcandBackend( unittest.TestCase ):
@@ -23,18 +23,19 @@ class TestVulcandBackend( unittest.TestCase ):
         ])
 
         self.etcd_client = MockEtcd()
-
         self.container = {
             'Image': 'image:latest',
             'Ports': [{
                 'PrivatePort': 9200,
                 'IP': '0.0.0.0',
                 'Type': 'tcp',
-                'PublicPort': 9200 }, {
+                'PublicPort': 9200
+            }, {
                 'PrivatePort': 9300,
                 'IP': '0.0.0.0',
                 'Type': 'tcp',
-                'PublicPort': 9300}],
+                'PublicPort': 9300
+            }],
             'Created': 1427906382,
             'Names': ['/test'],
             'Status': 'Up 2 days'
@@ -43,4 +44,20 @@ class TestVulcandBackend( unittest.TestCase ):
     def test_vulcand_announce( self ):
         """ Test `announce_services` functionality """
         services = find_matching_container( [ self.container ], self.args )
-        announce_services( services.items(), 'test', self.etcd_client, 0, 0, True )
+
+        # Successful health check
+        with patch( 'sidekick.check_health', return_value=True ):
+            announce_services( services.items(), 'test', self.etcd_client, 0, 0, True )
+            self.assertEqual( len( self.etcd_client.written.keys() ), 4 )
+
+        # Unsuccessful health check
+        self.etcd_client._reset()
+        with patch( 'sidekick.check_health', return_value=False ):
+            announce_services( services.items(), 'test', self.etcd_client, 0, 0, True )
+            self.assertEqual( len( self.etcd_client.deleted ), 4 )
+
+        # Correct etcd exception handling
+        self.etcd_client = MockEtcd( raise_exception=True )
+        with patch( 'logging.error' ) as mock_method:
+            announce_services( services.items(), 'test', self.etcd_client, 0, 0, True )
+            self.assertEquals( str(mock_method.call_args[0][0]), 'Test Exception' )

--- a/tests/backends/test_vulcand.py
+++ b/tests/backends/test_vulcand.py
@@ -3,7 +3,7 @@
 # @Author: ahuynh
 # @Date:   2016-02-11 14:28:02
 # @Last Modified by:   ahuynh
-# @Last Modified time: 2016-02-11 17:27:07
+# @Last Modified time: 2016-02-26 16:15:00
 import unittest
 
 from sidekick import announce_services, find_matching_container, parse_args
@@ -47,17 +47,17 @@ class TestVulcandBackend( unittest.TestCase ):
 
         # Successful health check
         with patch( 'sidekick.check_health', return_value=True ):
-            announce_services( services.items(), 'test', self.etcd_client, 0, 0, True )
+            announce_services( services.items(), 'test', self.etcd_client, 0, 0, True, self.args )
             self.assertEqual( len( self.etcd_client.written.keys() ), 4 )
 
         # Unsuccessful health check
         self.etcd_client._reset()
         with patch( 'sidekick.check_health', return_value=False ):
-            announce_services( services.items(), 'test', self.etcd_client, 0, 0, True )
+            announce_services( services.items(), 'test', self.etcd_client, 0, 0, True, self.args )
             self.assertEqual( len( self.etcd_client.deleted ), 4 )
 
         # Correct etcd exception handling
         self.etcd_client = MockEtcd( raise_exception=True )
         with patch( 'logging.error' ) as mock_method:
-            announce_services( services.items(), 'test', self.etcd_client, 0, 0, True )
+            announce_services( services.items(), 'test', self.etcd_client, 0, 0, True, self.args )
             self.assertEquals( str(mock_method.call_args[0][0]), 'Test Exception' )

--- a/tests/backends/test_vulcand.py
+++ b/tests/backends/test_vulcand.py
@@ -3,7 +3,7 @@
 # @Author: ahuynh
 # @Date:   2016-02-11 14:28:02
 # @Last Modified by:   ahuynh
-# @Last Modified time: 2016-02-11 14:49:02
+# @Last Modified time: 2016-02-11 15:33:08
 import unittest
 
 from sidekick import announce_services, find_matching_container, parse_args
@@ -19,7 +19,7 @@ class TestVulcandBackend( unittest.TestCase ):
             '--name', 'test',
             '--ip', 'localhost',
             '--check-ip', '0.0.0.0',
-            '--vulcand'
+            '--vulcand', 'True'
         ])
 
         self.etcd_client = MockEtcd()
@@ -40,7 +40,7 @@ class TestVulcandBackend( unittest.TestCase ):
             'Status': 'Up 2 days'
         }
 
-        def test_announce_services( self ):
-            """ Test `announce_services` functionality """
-            services = find_matching_container( [ self.container ], self.args )
-            announce_services( services.items(), 'test', self.etcd_client, 0, 0, True )
+    def test_vulcand_announce( self ):
+        """ Test `announce_services` functionality """
+        services = find_matching_container( [ self.container ], self.args )
+        announce_services( services.items(), 'test', self.etcd_client, 0, 0, True )

--- a/tests/test_sidekick.py
+++ b/tests/test_sidekick.py
@@ -3,13 +3,13 @@
 # @Author: ahuynh
 # @Date:   2015-06-18 20:15:30
 # @Last Modified by:   ahuynh
-# @Last Modified time: 2016-02-11 16:42:23
+# @Last Modified time: 2016-02-11 17:27:50
 import unittest
 
 from sidekick import announce_services, check_name, find_matching_container
 from sidekick import check_health, public_ports, parse_args
-
 from tests import MockEtcd
+from unittest.mock import patch
 
 
 class TestSidekick( unittest.TestCase ):
@@ -38,13 +38,37 @@ class TestSidekick( unittest.TestCase ):
     def test_announce_services( self ):
         """ Test `announce_services` functionality """
         services = find_matching_container( [self.container], self.args )
-        announce_services( services.items(), 'test', self.etcd_client, 0, 0, False )
+
+        # Test successful health check
+        with patch( 'sidekick.check_health', return_value=True ):
+            announce_services( services.items(), 'test', self.etcd_client, 0, 0, False )
+            self.assertEqual( len( self.etcd_client.written.keys() ), 2 )
+
+        # Test unsuccessful health check
+        with patch( 'sidekick.check_health', return_value=False ):
+            announce_services( services.items(), 'test', self.etcd_client, 0, 0, False )
+            self.assertEqual( len( self.etcd_client.deleted ), 2 )
+
+        # Test correct etcd exception handling
+        self.etcd_client = MockEtcd( raise_exception=True )
+        with patch( 'logging.error' ) as mock_method:
+            announce_services( services.items(), 'test', self.etcd_client, 0, 0, False )
+            self.assertEquals( str(mock_method.call_args[0][0]), 'Test Exception' )
 
     def test_check_health( self ):
         """ Test `check_health` functionality """
         results = find_matching_container( [self.container], self.args )
+
         for value in results.values():
+            # Unsuccessful socket connection
             self.assertFalse( check_health( value ) )
+
+            # Successful socket connection
+            with patch( 'socket.socket.connect' ) as mock_method:
+                check_health( value )
+                args = mock_method.call_args[0][0]
+                self.assertEqual( args[0], value[ 'check_ip' ] )
+                self.assertEqual( args[1], value[ 'port' ] )
 
     def test_check_name( self ):
         """ Test `check_name` functionality """

--- a/tests/test_sidekick.py
+++ b/tests/test_sidekick.py
@@ -3,7 +3,7 @@
 # @Author: ahuynh
 # @Date:   2015-06-18 20:15:30
 # @Last Modified by:   ahuynh
-# @Last Modified time: 2016-02-11 16:41:47
+# @Last Modified time: 2016-02-11 16:42:23
 import unittest
 
 from sidekick import announce_services, check_name, find_matching_container
@@ -32,7 +32,8 @@ class TestSidekick( unittest.TestCase ):
                 'PublicPort': 9300}],
             'Created': 1427906382,
             'Names': ['/test'],
-            'Status': 'Up 2 days'}
+            'Status': 'Up 2 days'
+        }
 
     def test_announce_services( self ):
         """ Test `announce_services` functionality """

--- a/tests/test_sidekick.py
+++ b/tests/test_sidekick.py
@@ -3,30 +3,20 @@
 # @Author: ahuynh
 # @Date:   2015-06-18 20:15:30
 # @Last Modified by:   ahuynh
-# @Last Modified time: 2015-06-19 17:06:28
+# @Last Modified time: 2016-02-11 14:31:01
 import unittest
 
-from collections import namedtuple
 from sidekick import announce_services, check_name, find_matching_container
-from sidekick import check_health, public_ports
+from sidekick import check_health, public_ports, parse_args
 
-# Used to test command line arguments
-Args = namedtuple('Args', ['name', 'ip', 'check_ip', 'vulcand'])
-
-
-class MockEtcd( object ):
-    def delete( self, value ):
-        pass
-
-    def write( self, value, ttl ):
-        pass
+from tests import MockEtcd
 
 
 class TestSidekick( unittest.TestCase ):
 
     def setUp( self ):
 
-        self.args = Args( name='test', ip='localhost', check_ip='0.0.0.0', vulcand=False )
+        self.args = parse_args( [ '--name', 'test', '--ip', 'localhost', '--check-ip', '0.0.0.0' ] )
 
         self.etcd_client  = MockEtcd()
 
@@ -46,23 +36,23 @@ class TestSidekick( unittest.TestCase ):
             'Status': 'Up 2 days'}
 
     def test_announce_services( self ):
-        ''' Test `announce_services` functionality '''
+        """ Test `announce_services` functionality """
         services = find_matching_container( [self.container], self.args )
         announce_services( services.items(), 'test', self.etcd_client, 0, 0, False )
 
     def test_check_health( self ):
-        ''' Test `check_health` functionality '''
+        """ Test `check_health` functionality """
         results = find_matching_container( [self.container], self.args )
         for value in results.values():
             self.assertFalse( check_health( value ) )
 
     def test_check_name( self ):
-        ''' Test `check_name` functionality '''
+        """ Test `check_name` functionality """
         self.assertTrue( check_name( self.container, 'test' ) )
         self.assertFalse( check_name( self.container, '/test' ) )
 
     def test_find_matching_container( self ):
-        ''' Test `find_matching_container` functionality '''
+        """ Test `find_matching_container` functionality """
         # Test a successful match
         results = find_matching_container( [self.container], self.args )
         self.assertEqual( len( results.items() ), 2 )
@@ -80,5 +70,5 @@ class TestSidekick( unittest.TestCase ):
             find_matching_container( [no_open_ports], self.args )
 
     def test_public_ports( self ):
-        ''' Test `public_ports` functionality '''
+        """ Test `public_ports` functionality """
         self.assertEquals( len( public_ports( self.container ) ), 2 )

--- a/tests/test_sidekick.py
+++ b/tests/test_sidekick.py
@@ -3,7 +3,7 @@
 # @Author: ahuynh
 # @Date:   2015-06-18 20:15:30
 # @Last Modified by:   ahuynh
-# @Last Modified time: 2016-02-11 17:27:50
+# @Last Modified time: 2016-02-26 16:14:09
 import unittest
 
 from sidekick import announce_services, check_name, find_matching_container
@@ -41,18 +41,18 @@ class TestSidekick( unittest.TestCase ):
 
         # Test successful health check
         with patch( 'sidekick.check_health', return_value=True ):
-            announce_services( services.items(), 'test', self.etcd_client, 0, 0, False )
+            announce_services( services.items(), 'test', self.etcd_client, 0, 0, False, self.args )
             self.assertEqual( len( self.etcd_client.written.keys() ), 2 )
 
         # Test unsuccessful health check
         with patch( 'sidekick.check_health', return_value=False ):
-            announce_services( services.items(), 'test', self.etcd_client, 0, 0, False )
+            announce_services( services.items(), 'test', self.etcd_client, 0, 0, False, self.args )
             self.assertEqual( len( self.etcd_client.deleted ), 2 )
 
         # Test correct etcd exception handling
         self.etcd_client = MockEtcd( raise_exception=True )
         with patch( 'logging.error' ) as mock_method:
-            announce_services( services.items(), 'test', self.etcd_client, 0, 0, False )
+            announce_services( services.items(), 'test', self.etcd_client, 0, 0, False, self.args )
             self.assertEquals( str(mock_method.call_args[0][0]), 'Test Exception' )
 
     def test_check_health( self ):

--- a/tests/test_vulcand.py
+++ b/tests/test_vulcand.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# @Author: ahuynh
+# @Date:   2016-02-11 14:28:02
+# @Last Modified by:   ahuynh
+# @Last Modified time: 2016-02-11 14:49:02
+import unittest
+
+from sidekick import announce_services, find_matching_container, parse_args
+
+from tests import MockEtcd
+
+
+class TestVulcandBackend( unittest.TestCase ):
+
+    def setUp( self ):
+
+        self.args = parse_args([
+            '--name', 'test',
+            '--ip', 'localhost',
+            '--check-ip', '0.0.0.0',
+            '--vulcand'
+        ])
+
+        self.etcd_client = MockEtcd()
+
+        self.container = {
+            'Image': 'image:latest',
+            'Ports': [{
+                'PrivatePort': 9200,
+                'IP': '0.0.0.0',
+                'Type': 'tcp',
+                'PublicPort': 9200 }, {
+                'PrivatePort': 9300,
+                'IP': '0.0.0.0',
+                'Type': 'tcp',
+                'PublicPort': 9300}],
+            'Created': 1427906382,
+            'Names': ['/test'],
+            'Status': 'Up 2 days'
+        }
+
+        def test_announce_services( self ):
+            """ Test `announce_services` functionality """
+            services = find_matching_container( [ self.container ], self.args )
+            announce_services( services.items(), 'test', self.etcd_client, 0, 0, True )


### PR DESCRIPTION
- [x] Added tests for vulcand support and functionality
- [x] Added flag to add "TrustForwardedHeader" to frontend settings when true. This flag makes sure vulcand doesn't mangle any X-Forwarded-\* headers when sitting behind a proxy.
